### PR TITLE
Add support for  aliases

### DIFF
--- a/mongoquery/__init__.py
+++ b/mongoquery/__init__.py
@@ -173,6 +173,32 @@ class Query(object):
             17: int,  # Timestamp
             18: int   # 64-bit integer
         }
+        bson_alias = {
+            "double": 1,
+            "string": 2,
+            "object": 3,
+            "array": 4,
+            "binData": 5,
+            "objectId": 7,
+            "bool": 8,
+            "date": 9,
+            "null": 10,
+            "regex": 11,
+            "javascript": 13,
+            "javascriptWithScope": 15,
+            "int": 16,
+            "timestamp": 17,
+            "long": 18,
+        }
+
+        if condition == "number":
+            return any([
+                isinstance(entry, bson_type[bson_alias[alias]])
+                for alias in ["double", "int", "long"]
+                ])
+
+        # resolves bson alias, or keeps original condition value
+        condition = bson_alias.get(condition, condition)
 
         if condition not in bson_type:
             raise QueryError(

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -95,6 +95,21 @@ class TestQuery(TestCase):
 
         self.assertEqual(
             _ALL,
+            self._query({"qty": {"$type": 'int'}})
+        )
+
+        self.assertEqual(
+            _ALL,
+            self._query({"qty": {"$type": 'number'}})
+        )
+
+        self.assertEqual(
+            [],
+            self._query({"qty": {"$type": 'string'}})
+        )
+
+        self.assertEqual(
+            _ALL,
             self._query({"qty": {"$exists": True}})
         )
 


### PR DESCRIPTION
Since version 3.2 Mongo supports string aliases for `$type` operator (https://docs.mongodb.com/manual/reference/operator/query/type/#available-types).
This patch adds the functionality (and some tests) to the library.
