### PR TITLE
Fixed $exists on JSON paths

### DIFF
--- a/mongoquery/__init__.py
+++ b/mongoquery/__init__.py
@@ -238,18 +238,6 @@ class Query(object):
 
     exists = _noop
 
-
-        
-    # def _exists(self, condition, entry):
-    #     if type(entry) is list:
-    #         for e in entry:
-    #             if not isinstance(entry, _Undefined):
-    #                 return condition
-    #             return not condition
-    #     if not isinstance(entry, _Undefined):
-    #         return condition
-    #     return not condition
-
     def _mod(self, condition, entry):
         return entry % condition[0] == condition[1]
 

--- a/mongoquery/__init__.py
+++ b/mongoquery/__init__.py
@@ -232,7 +232,7 @@ class Query(object):
 
         return isinstance(entry, bson_type.get(condition))
 
-    exists = _noop
+    _exists = _noop
 
     ######################
     # Evaluation operators

--- a/mongoquery/__init__.py
+++ b/mongoquery/__init__.py
@@ -76,7 +76,7 @@ class Query(object):
 
     def _process_condition(self, operator, condition, entry):
         if isinstance(condition, Mapping) and "$exists" in condition:
-            if type(operator) is str and operator.find('.') != -1:
+            if type(operator) is str and (operator.find('.') != -1 or operator.find('[') != -1):
                 return self._path_exists(operator, condition['$exists'], entry)
             elif condition["$exists"] != (operator in entry):
                 return False

--- a/mongoquery/__init__.py
+++ b/mongoquery/__init__.py
@@ -232,11 +232,11 @@ class Query(object):
 
         return isinstance(entry, bson_type.get(condition))
 
+    exists = _noop
+
     ######################
     # Evaluation operators
     ######################
-
-    exists = _noop
 
     def _mod(self, condition, entry):
         return entry % condition[0] == condition[1]

--- a/mongoquery/__init__.py
+++ b/mongoquery/__init__.py
@@ -64,6 +64,8 @@ class Query(object):
         for k in keys:
             if k.endswith(']'):
                 k = int(k[:-1])
+            if type(obj) is str:
+                raise KeyError("Invalid key '{}' in JSON path".format(k))
             obj = obj[k]
         return obj
 

--- a/mongoquery/__init__.py
+++ b/mongoquery/__init__.py
@@ -55,11 +55,6 @@ class Query(object):
             return _Undefined()
 
     def _process_condition(self, operator, condition, entry):
-        if isinstance(condition, Mapping) and "$exists" in condition:
-            if condition["$exists"] != (operator in entry):
-                return False
-            elif tuple(condition.keys()) == ("$exists",):
-                return True
         if isinstance(operator, string_type):
             if operator.startswith("$"):
                 try:
@@ -210,11 +205,14 @@ class Query(object):
 
         return isinstance(entry, bson_type.get(condition))
 
-    _exists = _noop
-
     ######################
     # Evaluation operators
     ######################
+
+    def _exists(self, condition, entry):
+        if not isinstance(entry, _Undefined):
+            return condition
+        return not condition
 
     def _mod(self, condition, entry):
         return entry % condition[0] == condition[1]


### PR DESCRIPTION
I implemented a method which resolves the value for a JSON path within an object.

The method handles both dotted JSON paths and index `[]` JSON paths. 

Using this method I was able to test the existence of the key at path. It only triggers when the operator for the condition is a dotted `.` string or a bracketted `[]` string for $exists path, so existing code is not affected.