### PR TITLE
Better support for $exists + 2 bugfixes

### DIFF
--- a/mongoquery/__init__.py
+++ b/mongoquery/__init__.py
@@ -304,6 +304,8 @@ class Query(object):
         )
 
     def _elemMatch(self, condition, entry):
+        if not isinstance(entry, Sequence):
+            return False
         return any(
             all(
                 self._process_condition(sub_operator, sub_condition, element)

--- a/mongoquery/__init__.py
+++ b/mongoquery/__init__.py
@@ -84,9 +84,8 @@ class Query(object):
                 return True
         if isinstance(operator, string_type):
             if operator.startswith("$"):
-                operator = "_" + operator[1:]
                 try:
-                    return getattr(self, operator)(condition, entry)
+                    return getattr(self, "_" + operator[1:])(condition, entry)
                 except AttributeError:
                     raise QueryError(
                         "{!r} operator isn't supported".format(operator))

--- a/mongoquery/__init__.py
+++ b/mongoquery/__init__.py
@@ -56,11 +56,11 @@ class Query(object):
             return _Undefined()
 
     def _path_exists(self, operator, condition, entry):
-        keys_lists = list(operator.split('.'))
-        for i, k in enumerate(keys_lists):
+        keys_list = list(operator.split('.'))
+        for i, k in enumerate(keys_list):
             if isinstance(entry, Sequence) and not k.isdigit():
                 for e in entry:
-                    operator = '.'.join(keys_lists[i:])
+                    operator = '.'.join(keys_list[i:])
                     if self._path_exists(operator, condition, e) == condition:
                         return condition
                 return not condition

--- a/mongoquery/__init__.py
+++ b/mongoquery/__init__.py
@@ -89,10 +89,13 @@ class Query(object):
                 except AttributeError:
                     raise QueryError(
                         "{!r} operator isn't supported".format(operator))
-                except TypeError:
+                except TypeError as e:
                     return False
             else:
-                extracted_data = self._extract(entry, operator.split("."))
+                try:
+                    extracted_data = self._extract(entry, operator.split("."))
+                except IndexError:
+                    return False
         else:
             if operator not in entry:
                 return False

--- a/mongoquery/__init__.py
+++ b/mongoquery/__init__.py
@@ -61,10 +61,11 @@ class Query(object):
             keys_lists = [ path ]
         for i, k in enumerate(keys_lists):
             if isinstance(entry, Sequence) and not k.isdigit():
-              for e in entry:
-                  operator = '.'.join(keys_lists[i:])
-                  if self._path_exists(operator, condition, e) == condition:
-                      return condition
+                for e in entry:
+                    operator = '.'.join(keys_lists[i:])
+                    if self._path_exists(operator, condition, e) == condition:
+                        return condition
+                return not condition
             elif isinstance(entry, Sequence):
                 k = int(k)
             try:

--- a/mongoquery/__init__.py
+++ b/mongoquery/__init__.py
@@ -55,10 +55,7 @@ class Query(object):
             return _Undefined()
 
     def _path_exists(self, operator, condition, entry):
-        if type(operator) is str:
-            keys_lists = list(operator.split('.'))
-        else:
-            keys_lists = [ path ]
+        keys_lists = list(operator.split('.'))
         for i, k in enumerate(keys_lists):
             if isinstance(entry, Sequence) and not k.isdigit():
                 for e in entry:
@@ -76,7 +73,7 @@ class Query(object):
 
     def _process_condition(self, operator, condition, entry):
         if isinstance(condition, Mapping) and "$exists" in condition:
-            if type(operator) is str and operator.find('.') != -1:
+            if isinstance(operator, basestring) and operator.find('.') != -1:
                 return self._path_exists(operator, condition['$exists'], entry)
             elif condition["$exists"] != (operator in entry):
                 return False
@@ -146,7 +143,7 @@ class Query(object):
 
     def _ne(self, condition, entry):
         return entry != condition
-            
+
     def _nin(self, condition, entry):
         try:
             return entry not in condition

--- a/mongoquery/__init__.py
+++ b/mongoquery/__init__.py
@@ -84,13 +84,12 @@ class Query(object):
                 return True
         if isinstance(operator, string_type):
             if operator.startswith("$"):
+                operator = "_" + operator[1:]
                 try:
-                    return getattr(self, "_" + operator[1:])(condition, entry)
+                    return getattr(self, operator)(condition, entry)
                 except AttributeError:
                     raise QueryError(
                         "{!r} operator isn't supported".format(operator))
-                except TypeError as e:
-                    return False
             else:
                 try:
                     extracted_data = self._extract(entry, operator.split("."))
@@ -117,25 +116,43 @@ class Query(object):
     ######################
 
     def _gt(self, condition, entry):
-        return entry > condition
+        try:
+            return entry > condition
+        except TypeError:
+            return False
 
     def _gte(self, condition, entry):
-        return entry >= condition
+        try:
+            return entry >= condition
+        except TypeError:
+            return False
 
     def _in(self, condition, entry):
-        return entry in condition
+        try:
+            return entry in condition
+        except TypeError:
+            return False
 
     def _lt(self, condition, entry):
-        return entry < condition
+        try:
+            return entry < condition
+        except TypeError:
+            return False
 
     def _lte(self, condition, entry):
-        return entry <= condition
+        try:
+            return entry <= condition
+        except TypeError:
+            return False
 
     def _ne(self, condition, entry):
         return entry != condition
-
+            
     def _nin(self, condition, entry):
-        return entry not in condition
+        try:
+            return entry not in condition
+        except TypeError:
+            return True
 
     ###################
     # Logical operators

--- a/mongoquery/__init__.py
+++ b/mongoquery/__init__.py
@@ -1,5 +1,6 @@
 import re
 from collections import Sequence, Mapping
+from six import string_types
 
 try:
     string_type = basestring
@@ -73,7 +74,7 @@ class Query(object):
 
     def _process_condition(self, operator, condition, entry):
         if isinstance(condition, Mapping) and "$exists" in condition:
-            if isinstance(operator, basestring) and operator.find('.') != -1:
+            if isinstance(operator, string_types) and operator.find('.') != -1:
                 return self._path_exists(operator, condition['$exists'], entry)
             elif condition["$exists"] != (operator in entry):
                 return False

--- a/mongoquery/__init__.py
+++ b/mongoquery/__init__.py
@@ -54,31 +54,23 @@ class Query(object):
         else:
             return _Undefined()
 
-    def _get_value_at_path(self, obj, path):
-        is_dotted = True if path.find(".") != -1 else False
-        is_indexed = True if path.find("[") != -1 else False
-        if is_indexed:
-            path = path.replace("[", ".")
-            is_dotted = True
-        keys = " ".join(path.split(".")).split() if is_dotted else [ path ]
-        for k in keys:
-            if k.endswith(']'):
-                k = int(k[:-1])
-            if type(obj) is str:
-                raise KeyError("Invalid key '{}' in JSON path".format(k))
-            obj = obj[k]
-        return obj
-
     def _path_exists(self, operator, condition, entry):
-        try:
-            self._get_value_at_path(entry, operator)
-        except:
-            return not condition
+        if type(operator) is str:
+            keys_lists = list(operator.split('.'))
+        else:
+            keys_lists = [ path ]
+        for k in keys_lists:
+            if isinstance(entry, Sequence):
+                k = int(k)
+            try:
+                entry = entry[k]
+            except:
+                return not condition
         return condition
 
     def _process_condition(self, operator, condition, entry):
         if isinstance(condition, Mapping) and "$exists" in condition:
-            if type(operator) is str and (operator.find('.') != -1 or operator.find('[') != -1):
+            if type(operator) is str and operator.find('.') != -1:
                 return self._path_exists(operator, condition['$exists'], entry)
             elif condition["$exists"] != (operator in entry):
                 return False
@@ -91,6 +83,8 @@ class Query(object):
                 except AttributeError:
                     raise QueryError(
                         "{!r} operator isn't supported".format(operator))
+                except TypeError:
+                    return False
             else:
                 extracted_data = self._extract(entry, operator.split("."))
         else:

--- a/mongoquery/__init__.py
+++ b/mongoquery/__init__.py
@@ -95,7 +95,7 @@ class Query(object):
                 try:
                     extracted_data = self._extract(entry, operator.split("."))
                 except IndexError:
-                    return False
+                    extracted_data = _Undefined()
         else:
             if operator not in entry:
                 return False

--- a/mongoquery/__init__.py
+++ b/mongoquery/__init__.py
@@ -59,8 +59,13 @@ class Query(object):
             keys_lists = list(operator.split('.'))
         else:
             keys_lists = [ path ]
-        for k in keys_lists:
-            if isinstance(entry, Sequence):
+        for i, k in enumerate(keys_lists):
+            if isinstance(entry, Sequence) and not k.isdigit():
+              for e in entry:
+                  operator = '.'.join(keys_lists[i:])
+                  if self._path_exists(operator, condition, e) == condition:
+                      return condition
+            elif isinstance(entry, Sequence):
                 k = int(k)
             try:
                 entry = entry[k]


### PR DESCRIPTION
This is a rebased version of #10 that just corrects the commit authorship. From the original PR:

This PR upgrades:

    $exists now only follows the dotted notation and no longer supports brackets '[]' for list index annotation which makes it more consistent with modern MongoDB query standard

    $exists will now recurse into lists just as mongodb, and will recurse even more than MongoDB (MongoDB does not support nested arrays very well... $exists in mongoquery will do)

Fixes two bug:

    The following code was causing a TypeError exception:

    from mongoquery import Query
    q = Query({'a':{'$gt':3}})
    q.match({'b':'f'})

Now fixed with another exception handling case.

    The following code was causing an out of range exception:

    from mongoquery import Query
    q = Query({'a.2':{'$in':3}})
    q.match({'a':[0,1]})

I made an exception handling in most of comparison operators, I think it was the right thing to do in order to properly manage the return value expected (example: nin returns True not False on error)