### PR TITLE
Fix import of abstract container classes to Python 3.9 compatible module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 language: python
 python:
-  - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
-  - "3.5-dev" # 3.5 development branch
-  - "nightly" # currently points to 3.6-dev
+  - "3.6"
+  - "3.7"
+  - "3.8"
+  - "3.9-dev"
+  - "nightly"
 # command to install dependencies
-install: 
+install:
   - pip install .
   - pip install nose
 # command to run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ python:
 # command to install dependencies
 install:
   - pip install .
-  - pip install nose
+  - pip install pytest
 # command to run tests
-script: nosetests
+script: pytest

--- a/mongoquery/__init__.py
+++ b/mongoquery/__init__.py
@@ -4,7 +4,7 @@ MongoDB Query Language queries.
 """
 
 import re
-from collections import Sequence, Mapping
+from collections.abc import Sequence, Mapping
 from six import string_types
 
 # pylint: disable=invalid-name


### PR DESCRIPTION
This should address issue #21 