### PR TITLE
Allow compiled regexes to be supplied as values

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -125,7 +125,9 @@ Functional differences with MongoDB's queries
 
 There are a few features that are not supported by ``mongoquery``:
     - Only the ``"/pattern/<options>"`` syntax is supported for ``$regex``. As
-      a consequence, ``$options`` isn't supported.
+      a consequence, ``$options`` isn't supported. Alternatively you can
+      compile a regex using ``re.compile`` and supply options as parameters, and pass
+      the ``re.Pattern`` object as the value of ``$regex``.
     - ``$text`` hasn't been implemented.
     - Due to the pure python nature of this library, ``$where`` isn't supported.
     - The `Geospatial` operators ``$geoIntersects``, ``$geoWithin``,

--- a/mongoquery/__init__.py
+++ b/mongoquery/__init__.py
@@ -14,6 +14,14 @@ except NameError:
     string_type = str
 
 
+# Pythons >= 3.7 have a nice Pattern type we can use. Olders versions
+# require a different type.
+try:
+    regex_type = re.Pattern
+except AttributeError:
+    regex_type = re._pattern_type
+
+
 class QueryError(Exception):
     """ Query error exception """
     pass
@@ -239,7 +247,7 @@ class Query(object):
             8: bool,
             9: string_type,  # date (UTC datetime)
             10: type(None),
-            11: string_type,  # regex,
+            11: regex_type,  # regex,
             13: string_type,  # Javascript
             15: string_type,  # JavaScript (with scope)
             16: int,  # 32-bit integer
@@ -293,6 +301,10 @@ class Query(object):
     def _regex(condition, entry):
         if not isinstance(entry, string_type):
             return False
+        # If the caller has supplied a compiled regex, assume options are already
+        # included.
+        if isinstance(condition, regex_type):
+            return bool(re.search(condition, entry))
         try:
             regex = re.match(
                 r"\A/(.+)/([imsx]{,4})\Z",

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,3 +1,4 @@
+import re
 from unittest import TestCase
 from mongoquery import Query
 
@@ -198,6 +199,11 @@ class TestQuery(TestCase):
         self.assertEqual(
             products[:2],
             self._query({"sku": {"$regex": "/^ABC/i"}}, collection=products)
+        )
+        self.assertEqual(
+            products[:2],
+            self._query({"sku": {"$regex": re.compile("^ABC", re.IGNORECASE)}},
+                        collection=products)
         )
 
         self.assertEqual(


### PR DESCRIPTION
    * This allows greater compatibility with pymongo, which accepts compiled
      regexes as `$regex` values, along with options (i.e. `re.IGNORECASE`).

TBH I wasn't really sure if the `bson_alias` and `bson_type` tables needed updating, but it seems nice for completeness.