### PR TITLE
Allow exact match for lists

### DIFF
--- a/mongoquery/__init__.py
+++ b/mongoquery/__init__.py
@@ -362,6 +362,9 @@ class Query(object):
 
     @staticmethod
     def _size(condition, entry):
+        if isinstance(condition, Mapping):
+            return Query(condition).match(len(entry))
+
         if not isinstance(condition, int):
             raise QueryError(
                 "$size has been attributed incorrect argument {!r}".format(

--- a/mongoquery/__init__.py
+++ b/mongoquery/__init__.py
@@ -53,9 +53,12 @@ class Query(object):
                 self._process_condition(sub_operator, sub_condition, entry)
                 for sub_operator, sub_condition in condition.items()
             )
+        if condition == entry:
+            return True
+
         if is_non_string_sequence(entry):
             return condition in entry
-        return condition == entry
+        return False
 
     def _extract(self, entry, path):
         if not path:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -67,7 +67,7 @@ class TestQuery(TestCase):
             _ALL,
             self._query({"ratings": {"$in": [5, 6]}})
         )
-        
+
         self.assertEqual(
             [_FRUIT],
             self._query({"qty": {"$in": [10, 42]}})
@@ -266,6 +266,13 @@ class TestQuery(TestCase):
                         "by": 'shipping'
                     }
                 }
+            })
+        )
+
+        self.assertEqual(
+            [_FOOD],
+            self._query({
+                "ratings": [5, 8, 9]
             })
         )
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,5 +1,6 @@
 import re
 from unittest import TestCase
+
 from mongoquery import Query
 
 _FOOD = {
@@ -273,6 +274,17 @@ class TestQuery(TestCase):
             [_FOOD],
             self._query({
                 "ratings": [5, 8, 9]
+            })
+        )
+
+        self.assertEqual(
+            [_FOOD],
+            self._query({
+                "ratings": {
+                    "$size": {
+                        "$gt" : 2
+                    }
+                }
             })
         )
 


### PR DESCRIPTION
1.  Exact match on values of type array (list) doesn't work.
Fixed by matching condition to entry by  `==` operator before `in`.
Unit test added:
`"ratings": [5, 8, 9]` on test data `_FOOD`

2. Fix $size with condition doesn't work. e.g., {$size: { $gt: 1 }}
Unit test added:
`"ratings": { "$size": {"$gt": 2 } }` on test data `_FOOD`
